### PR TITLE
docs: add macOS timeout fix instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ Stage some changes first.
 git add .
 ```
 
+## macOS Issues
+
+❌ timeout: command not found
+
+Install GNU coreutils
+
+```sh
+brew install coreutils
+```
+
 # 🤝 Contributing
 
 We welcome contributions! Whether you're fixing bugs, adding features, or improving documentation, your help makes `faff` better for everyone.


### PR DESCRIPTION
## Description
- update README with instructions to install GNU coreutils on macOS to resolve timeout issue

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update (changes to documentation only)
- [ ] 🎨 Code style/formatting (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement

## Testing

Please describe how you tested your changes:

- [x] Tested with simple git diffs
- [ ] Tested with complex multi-file changes
- [ ] Tested error scenarios (no changes, invalid models, etc.)
- [ ] Tested with different qwen2.5-coder models
- [ ] Tested environment variable configurations
- [ ] Manual testing completed

### Test Scenarios (if applicable)

n/a

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have tested my changes thoroughly
- [ ] Any dependent changes have been merged and published

## Related Issues

Fixes #13

## Additional Context

There's another showstopper once this is fixed, but i don't have time to address it at the moment.
