### PR TITLE
fix: add bash version check in dependency check function

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ So yes, `faff` is another bloody AI commit generator. The Internet's already dro
 - [**Ollama**](https://ollama.ai/) installed and running somewhere
 - [coreutils](https://www.gnu.org/software/coreutils/) or [uutils/coreutils](https://github.com/uutils/coreutils)
 - `bc`, `curl` and `jq`
+- Bash version 4.0 or later.
 - A **git repository** with staged changes
 
 ## Install
@@ -131,16 +132,6 @@ Stage some changes first.
 
 ```bash
 git add .
-```
-
-## macOS Issues
-
-❌ timeout: command not found
-
-Install GNU coreutils
-
-```sh
-brew install coreutils
 ```
 
 # 🤝 Contributing

--- a/faff.sh
+++ b/faff.sh
@@ -118,6 +118,7 @@ function check_dependencies() {
     command -v jq &>/dev/null || error_exit "jq is not installed. Please install it and try again."
     command -v timeout &>/dev/null || error_exit "timeout is not installed. Please install coreutils or uutils and try again."
     git rev-parse --is-inside-work-tree &>/dev/null || error_exit "This script must be run inside a Git repository."
+    ((BASH_VERSINFO[0] < 4)) && error_exit "bash version 4.0 or higher is not installed. Please install a recent version of bash and try again."
 }
 
 # Function to show spinner during API calls


### PR DESCRIPTION
## Description

- added check for minimum required bash version (4.0 or higher) in `check_dependencies` function

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update (changes to documentation only)
- [ ] 🎨 Code style/formatting (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement

## Testing

Please describe how you tested your changes:

- [x] Tested with simple git diffs
- [ ] Tested with complex multi-file changes
- [ ] Tested error scenarios (no changes, invalid models, etc.)
- [ ] Tested with different qwen2.5-coder models
- [ ] Tested environment variable configurations
- [x] Manual testing completed

### Test Scenarios (if applicable)

Executed faff.sh both with bash 3.x and bash 5.x installed to ensure the script handles both cases.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly
- [ ] Any dependent changes have been merged and published

## Related Issues

Fixes #15

## Additional Context


