### PR TITLE
feat(cli): add commitlint integration for scoped commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,9 +26,11 @@ bash -n faff.sh
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `FAFF_MODEL` | `qwen2.5-coder:7b` | Ollama model to use |
+| `FAFF_TIMEOUT` | `180` | API timeout in seconds |
 | `OLLAMA_HOST` | `localhost` | Ollama server hostname |
 | `OLLAMA_PORT` | `11434` | Ollama server port |
-| `FAFF_TIMEOUT` | `180` | API timeout in seconds |
+| `OLLAMA_PROTOCOL` | `http` | Protocol for Ollama connection (http/https) |
+| `OLLAMA_TOKEN` | (empty) | Optional API token for authenticated Ollama servers |
 
 ## Code style
 
@@ -61,11 +63,16 @@ Single script (`faff.sh`) with these key functions:
 - `main()` - Entry point, orchestrates workflow
 - `check_dependencies()` - Validates bash version and required tools
 - `get_git_diff()` - Retrieves staged changes
+- `get_allowed_scopes()` - Detects commitlint config and extracts allowed scopes
 - `generate_commit_message()` - Calls Ollama API with structured JSON output
 - `check_model()` - Auto-downloads missing models
 - `confirm_commit()` - Interactive prompt (y/n/e for yes/no/edit)
 
 The script embeds a detailed system prompt for Conventional Commits compliance, using Ollama's structured output format to ensure consistent JSON responses.
+
+## Integrations
+
+**Commitlint:** Auto-detects `.commitlintrc.json` or `commitlint.config.json` and extracts `scope-enum` to constrain LLM scope selection. Passive feature - no impact if no config exists.
 
 ## Constraints
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,29 @@ Add helpful aliases to your `~/.gitconfig`:
     vibe = "!git add . && faff"  # Stage all and commit with faff
 ```
 
+# 🔧 Commitlint Integration
+
+Got a [commitlint](https://commitlint.js.org/) config in your project? Lovely. `faff` will automatically detect it and constrain the AI to only use your allowed scopes - no configuration required, no extra dependencies, just works.
+
+If `faff` finds a `.commitlintrc.json` or `commitlint.config.json` in your repository, it extracts the scopes from `rules.scope-enum` and tells the LLM to stick to them. Your commits get the proper `type(scope): description` format without the AI going off-piste with invented scopes.
+
+No commitlint config? No worries - `faff` carries on exactly as before.
+
+## Example Config
+
+Here's a commitlint config that `faff` will pick up:
+
+```json
+{
+  "extends": ["@commitlint/config-conventional"],
+  "rules": {
+    "scope-enum": [2, "always", ["api", "cli", "docs", "tests"]]
+  }
+}
+```
+
+With this config, `faff` will only generate commits using `api`, `cli`, `docs`, or `tests` as scopes. Keeps everything tidy without you having to remember what scopes exist.
+
 # 🛟 Troubleshooting
 
 ## Common Issues

--- a/faff.sh
+++ b/faff.sh
@@ -101,6 +101,18 @@ function cleanup_temp_files() {
 	rm -f "$@"
 }
 
+# Get allowed scopes from commitlint configuration files
+function get_allowed_scopes() {
+	local config_files=(".commitlintrc.json" "commitlint.config.json")
+	for file in "${config_files[@]}"; do
+		if [[ -f "$file" ]]; then
+			jq -r '.rules."scope-enum"[2] // [] | join(", ")' "$file" 2>/dev/null
+			return
+		fi
+	done
+	echo ""
+}
+
 # Format download size in human-readable format (MB/GB)
 function format_download_size() {
 	local bytes="$1"
@@ -153,6 +165,10 @@ function get_git_diff() {
 function generate_commit_message() {
 	local diff="$1"
 
+	# Check for allowed scopes from commitlint configuration
+	local allowed_scopes
+	allowed_scopes=$(get_allowed_scopes)
+
 	# Create temporary files for all data to avoid ARG_MAX limits
 	local SYSTEM_PROMPT_FILE DIFF_FILE PAYLOAD_FILE RESPONSE_FILE EXIT_CODE_FILE
 	SYSTEM_PROMPT_FILE=$(mktemp)
@@ -161,51 +177,107 @@ function generate_commit_message() {
 	RESPONSE_FILE=$(mktemp)
 	EXIT_CODE_FILE=$(mktemp)
 
-	printf '%s' "$SYSTEM_PROMPT" >"$SYSTEM_PROMPT_FILE"
+	# Build system prompt, adding scope constraint if allowed scopes are found
+	if [[ -n "$allowed_scopes" ]]; then
+		printf '%s\n\nIMPORTANT: The [optional scope] MUST be one of these allowed values: %s. Do not use any other scope.' "$SYSTEM_PROMPT" "$allowed_scopes" >"$SYSTEM_PROMPT_FILE"
+	else
+		printf '%s' "$SYSTEM_PROMPT" >"$SYSTEM_PROMPT_FILE"
+	fi
 
 	# Write diff to temp file and escape for JSON using file input to avoid ARG_MAX
 	printf '%s' "$diff" >"$DIFF_FILE"
 	local GIT_DIFF
 	GIT_DIFF=$(jq -Rs . <"$DIFF_FILE")
 
-	jq -n \
-		--arg model "$FAFF_MODEL" \
-		--rawfile system "$SYSTEM_PROMPT_FILE" \
-		--argjson diff_content "$GIT_DIFF" \
-		'{
-        model: $model,
-        messages: [
-          {
-            role: "system",
-            content: $system
-          },
-          {
-            role: "user",
-            content: ("Here is the diff:\n\n" + $diff_content)
-          }
-        ],
-        stream: false,
-        format: {
-          type: "object",
-          properties: {
-            type: {
-              type: "string",
-              enum: ["feat", "fix", "build", "chore", "ci", "docs", "i18n", "perf", "refactor", "revert", "style", "test" ]
+	# Build the JSON payload with optional scope constraint
+	if [[ -n "$allowed_scopes" ]]; then
+		# Convert comma-separated scopes to JSON array
+		local scope_array
+		scope_array=$(echo "$allowed_scopes" | jq -R 'split(", ")')
+
+		jq -n \
+			--arg model "$FAFF_MODEL" \
+			--rawfile system "$SYSTEM_PROMPT_FILE" \
+			--argjson diff_content "$GIT_DIFF" \
+			--argjson scopes "$scope_array" \
+			'{
+            model: $model,
+            messages: [
+              {
+                role: "system",
+                content: $system
+              },
+              {
+                role: "user",
+                content: ("Here is the diff:\n\n" + $diff_content)
+              }
+            ],
+            stream: false,
+            format: {
+              type: "object",
+              properties: {
+                type: {
+                  type: "string",
+                  enum: ["feat", "fix", "build", "chore", "ci", "docs", "i18n", "perf", "refactor", "revert", "style", "test" ]
+                },
+                scope: {
+                  type: "string",
+                  enum: $scopes
+                },
+                description: {
+                  type: "string"
+                },
+                body: {
+                  type: "string"
+                }
+              },
+              required: ["type", "description"],
+              optional: ["scope", "body"]
             },
-            description: {
-              type: "string"
-            },
-            body: {
-              type: "string"
+            options: {
+              "temperature": 0.3
             }
-          },
-          required: ["type", "description"],
-          optional: ["body"]
-        },
-        options: {
-          "temperature": 0.3
-        }
-      }' >"$PAYLOAD_FILE"
+          }' >"$PAYLOAD_FILE"
+	else
+		jq -n \
+			--arg model "$FAFF_MODEL" \
+			--rawfile system "$SYSTEM_PROMPT_FILE" \
+			--argjson diff_content "$GIT_DIFF" \
+			'{
+            model: $model,
+            messages: [
+              {
+                role: "system",
+                content: $system
+              },
+              {
+                role: "user",
+                content: ("Here is the diff:\n\n" + $diff_content)
+              }
+            ],
+            stream: false,
+            format: {
+              type: "object",
+              properties: {
+                type: {
+                  type: "string",
+                  enum: ["feat", "fix", "build", "chore", "ci", "docs", "i18n", "perf", "refactor", "revert", "style", "test" ]
+                },
+                description: {
+                  type: "string"
+                },
+                body: {
+                  type: "string"
+                }
+              },
+              required: ["type", "description"],
+              optional: ["body"]
+            },
+            options: {
+              "temperature": 0.3
+            }
+          }' >"$PAYLOAD_FILE"
+	fi
 
 	local response
 	local curl_exit_code=0
@@ -261,8 +333,9 @@ function generate_commit_message() {
 	fi
 
 	# Attempt to parse the message content as JSON
-	local type description body
+	local type scope description body
 	if ! type=$(echo "$message_content" | jq -r '.type // empty') ||
+		! scope=$(echo "$message_content" | jq -r '.scope // empty') ||
 		! description=$(echo "$message_content" | jq -r '.description // empty') ||
 		! body=$(echo "$message_content" | jq -r '.body // empty'); then
 		echo "Error: Could not parse type, description, or body from Ollama's message content." >&2
@@ -282,7 +355,13 @@ function generate_commit_message() {
 		return 0
 	fi
 
-	local final_commit_message="${type}: ${description}"
+	# Build commit message with optional scope
+	local final_commit_message
+	if [ -n "$scope" ] && [ "$scope" != "null" ]; then
+		final_commit_message="${type}(${scope}): ${description}"
+	else
+		final_commit_message="${type}: ${description}"
+	fi
 	if [ -n "$body" ] && [ "$body" != "null" ]; then
 		final_commit_message="${final_commit_message}\\n\\n${body}"
 	fi


### PR DESCRIPTION
- Auto-detect .commitlintrc.json and commitlint.config.json
- Extract scope-enum rules to constrain AI-generated commit scopes
- Update system prompt to enforce allowed scopes
- Parse and include scope in final commit message format
- Document new integration in README

Closes #17

## Description

Brief description of the changes in this pull request.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update (changes to documentation only)
- [ ] 🎨 Code style/formatting (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement

## Testing

Please describe how you tested your changes:

- [ ] Tested with simple git diffs
- [ ] Tested with complex multi-file changes
- [ ] Tested error scenarios (no changes, invalid models, etc.)
- [ ] Tested with different qwen2.5-coder models
- [ ] Tested environment variable configurations
- [ ] Manual testing completed

### Test Scenarios (if applicable)

```bash
# Example test commands you ran
echo "test change" >> README.md
git add README.md
./faff.sh
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have tested my changes thoroughly
- [ ] Any dependent changes have been merged and published

## Related Issues

Fixes #(issue_number)
Relates to #(issue_number)

## Additional Context

Add any other context about the pull request here. Include screenshots, examples, or other relevant information.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add commitlint integration to constrain commit scopes and format commits as type(scope): description. The CLI auto-detects `.commitlintrc.json` or `commitlint.config.json`, extracts `rules.scope-enum`, enforces allowed scopes in the system prompt and JSON schema, and updates README and AGENTS docs.

<sup>Written for commit 8448b4d60f03ff25b78f3afcddcc508601316bd6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

